### PR TITLE
Count between 2 and 33 instead of 34

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ exports.sentence = function sentence() {
         return array[random(array.length)];
     }
 
-    var count       = random(33) + 2,
+    var count       = random(32) + 2,
         adjective   = randomItem(exports.adjectives),
         noun        = randomItem(exports.nouns),
         verb        = randomItem(exports.verbs),

--- a/index.js
+++ b/index.js
@@ -94,9 +94,12 @@ exports.fromId = function(targetId) {
     return phrase;
 };
 
-// Confirm that Greg sentence corresponds to id
+// Confirm that Greg sentence is valid and corresponds to optional id
 exports.confirm = function(sentence, id) {
-    return exports.parse(sentence) === id;
+    if (null == id) {
+        id = exports.parse(sentence);
+    }
+    return exports.parse(sentence) === id && exports.fromId(id) === sentence;
 };
 
 // English adjectives

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Generate a Greg sentence
 exports.sentence = function sentence() {
     function random(max) {
@@ -26,8 +28,8 @@ exports.parse = function parse(sentence) {
         adverbFactor = verbFactor * exports.verbs.length,
         count = parseInt(words[0], 10),
         adjective = exports.adjectives.indexOf(words[1]),
-        noun = exports.nouns.indexOf(words[2])
-        verb = exports.verbs.indexOf(words[3])
+        noun = exports.nouns.indexOf(words[2]),
+        verb = exports.verbs.indexOf(words[3]),
         adverb = exports.adverbs.indexOf(words[4]);
 
     return count + 
@@ -35,6 +37,66 @@ exports.parse = function parse(sentence) {
         noun * nounFactor +
         verb * verbFactor +
         adverb * adverbFactor;
+};
+
+// Generate a Greg sentence from an id. 
+// Inverse of parse: greg.parse(greg.fromId(id)) === id for valid ids.
+// Valid range for ids is currently roughly between -5549438 and 22197761.
+// Warning: ids change if you change the number of adjectives, nouns, or verbs.
+exports.fromId = function(targetId) {
+    var     adjectiveFactor = 32,
+            nounFactor = adjectiveFactor * exports.adjectives.length,
+            verbFactor = nounFactor * exports.nouns.length,
+            adverbFactor = verbFactor * exports.verbs.length,
+            id = targetId - 2,
+            adverb = 0,
+            verb = 0,
+            noun = 0,
+            adjective = 0,
+            count = 0,
+            phrase = "",
+            limit = exports.adverbs.length - 1;
+            
+    adverb = Math.floor(id / adverbFactor);
+
+    if (adverb > limit) {
+        if (typeof console === "object" && console.warn) {
+            console.warn("Over the limit", id, count, adverb);
+        }
+        count += (adverb - limit - 1)*adverbFactor + (id % adverbFactor) + 1 ;
+        adverb = limit;
+        id -= count;
+        // console.log(id, count, adverb)
+    }
+
+    id -= adverb * adverbFactor;
+
+    verb = Math.floor(id / verbFactor);
+    id -= verb * verbFactor;
+
+    noun = Math.floor(id / nounFactor);
+    id -= noun * nounFactor;
+
+    adjective = Math.floor(id / adjectiveFactor);
+    id -= adjective * adjectiveFactor;
+
+    count += id + 2;
+
+    phrase = [count, exports.adjectives[adjective], exports.nouns[noun], exports.verbs[verb], exports.adverbs[adverb]].join(" ");
+
+    if (typeof console === "object" && console.warn) {
+        id = exports.parse(phrase);
+        if (id !== targetId) {
+            console.warn("does not match targetId", targetId, "!==", id);
+        }
+    }
+
+    return phrase;
+};
+
+// Confirm that Greg sentence corresponds to id
+exports.confirm = function(sentence, id) {
+    return exports.parse(sentence) === id;
 };
 
 // English adjectives
@@ -71,7 +133,7 @@ exports.verbs = [
     "sang", "played", "knitted", "floundered", "danced", "played", "listened", "ran",
     "talked", "cuddled", "sat", "kissed", "hugged", "whimpered", "hid", "fought",
     "whispered", "cried", "snuggled", "walked", "drove", "loitered", "whimpered", "felt",
-    "jumped", "hopped", "went", "married", "engaged", 
+    "jumped", "hopped", "went", "married", "engaged"
 ];
 
 // English adverbs

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "version": "0.0.2",
     "author": "Linus G Thiel <linus@hanssonlarsson.se>",
     "contributors": [
+        "Joshua S. Weinstein <http://github.com/josher19>"
     ],
     "dependencies": {},
     "keywords": ["word", "id", "generator", "error code"],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "greg",
     "description": "Unique, memorable ids for your Node app",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "author": "Linus G Thiel <linus@hanssonlarsson.se>",
     "contributors": [
         "Joshua S. Weinstein <http://github.com/josher19>"


### PR DESCRIPTION
It is currently possible to generate random sentences which are not the same but have the same id when parsed. Example:

``` js
exports = require('greg');

var phrase1 = '34 cute rabbits sang jovially',
    phrase2 = '2 dapper rabbits sang jovially';

exports.parse(phrase1) === exports.parse(phrase2); // true, both 34.
```

Updating the count to have a range from 2 to 33 instead of 2 to 34 fixes this.
